### PR TITLE
add DisplayNetwork support to android

### DIFF
--- a/colorchord2/android/AndroidManifest.xml
+++ b/colorchord2/android/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <uses-permission android:name="android.permission.SET_RELEASE_APP"/>
     <uses-permission android:name="android.permission.RECORD_AUDIO"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.INTERNET"/>
 
     <application android:debuggable="false" android:hasCode="false" android:label="colorchord"  tools:replace="android:icon,android:theme,android:allowBackup,label" android:icon="@mipmap/icon"  > <!--android:requestLegacyExternalStorage="true" Not needed til Android 29 -->
         <activity android:configChanges="keyboardHidden|orientation" android:label="colorchord" android:name="android.app.NativeActivity">

--- a/colorchord2/main.c
+++ b/colorchord2/main.c
@@ -385,6 +385,11 @@ int main(int argc, char ** argv)
 	{
 		AndroidRequestAppPermissions( "READ_EXTERNAL_STORAGE" );
 	}
+	int haspermInternet = AndroidHasPermissions( "INTERNET" );
+	if( !haspermInternet )
+	{
+		AndroidRequestAppPermissions( "INTERNET" );
+	}
 	
 
 #else


### PR DESCRIPTION
seems like `INTERNET` permission is the only one required to send packets

when testing that make sure to kill the app once and restart it so that on sencond load it can read the `/sdcard/colorchord-android.txt` config